### PR TITLE
Import only the necessary part of lodash

### DIFF
--- a/src/save-state.js
+++ b/src/save-state.js
@@ -1,4 +1,4 @@
-import { forEach, pickBy } from 'lodash';
+import { forEach, pickBy } from 'lodash/fp';
 import { saveState, getSavedState, clearSavedState } from './local-storage';
 
 export default {

--- a/src/save-state.js
+++ b/src/save-state.js
@@ -1,4 +1,5 @@
-import { forEach, pickBy } from 'lodash/fp';
+import pickBy from 'lodash/pickBy';
+import forEach from 'lodash/forEach';
 import { saveState, getSavedState, clearSavedState } from './local-storage';
 
 export default {


### PR DESCRIPTION
The current implementation loads the whole of lodash. Difference between the two import methods is about 44kB on dev builds. Since this library is very useful as a mixin, it would be nice if it didn't need to pull in lots of unnecessary code from lodash.