### PR TITLE
Add alternative component to use sessionStorage instead of localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# A Vue mixin to save the state of a component to local storage
+# A Vue mixin to save the state of a component to local or session storage
 
 [![Latest Version on NPM](https://img.shields.io/npm/v/vue-save-state.svg?style=flat-square)](https://npmjs.com/package/vue-save-state)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/spatie/vue-save-state/master.svg?style=flat-square)](https://travis-ci.org/spatie/vue-save-state)
 [![npm](https://img.shields.io/npm/dt/vue-save-state.svg?style=flat-square)](https://npmjs.com/package/vue-save-state)
 
-This package provides a `SaveState` mixin that automatically saves any change in the state of your component to localStorage. The next time that component gets initialized it will restore its state from the saved values in local storage.
+This package provides a `SaveState` mixin that automatically saves any change in the state of your component to localStorage or sessionStorage. The next time that component gets initialized it will restore its state from the saved values in local or session storage.
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
@@ -138,6 +138,22 @@ export default {
             };
         },
     },
+}
+```
+
+## Using sessionStorage instead of localStorage
+
+If you want to use sessionStorage instead of localStorage, you can just import `sessionSaveState` and use it the same way.
+
+```js
+import {sessionSaveState} from 'vue-save-state';
+
+export default {
+
+    mixins: [saveState],
+    
+    // ...
+
 }
 ```
 

--- a/src/local-storage.js
+++ b/src/local-storage.js
@@ -1,13 +1,15 @@
-export function saveState(key, data) {
+function saveState(key, data) {
     localStorage.setItem(key, JSON.stringify(data));
 }
 
-export function getSavedState(key) {
+function getSavedState(key) {
     const savedState = localStorage.getItem(key);
 
     return savedState ? JSON.parse(savedState) : null;
 }
 
-export function clearSavedState(key) {
+function clearSavedState(key) {
     localStorage.removeItem(key);
 }
+
+export default {saveState, getSavedState, clearSavedState};

--- a/src/save-state.js
+++ b/src/save-state.js
@@ -1,6 +1,7 @@
 import pickBy from 'lodash/pickBy';
 import forEach from 'lodash/forEach';
 import localStorage from './local-storage';
+import sessionStorage from './session-storage';
 
 const localSaveState = {
     watch: {
@@ -67,4 +68,11 @@ const localSaveState = {
     },
 };
 
+const sessionSaveState = {
+    mixins: [localSaveState],
+
+    $_saveState: sessionStorage,
+};
+
+export {localSaveState, sessionSaveState};
 export default localSaveState;

--- a/src/save-state.js
+++ b/src/save-state.js
@@ -1,8 +1,8 @@
 import pickBy from 'lodash/pickBy';
 import forEach from 'lodash/forEach';
-import { saveState, getSavedState, clearSavedState } from './local-storage';
+import localStorage from './local-storage';
 
-export default {
+const localSaveState = {
     watch: {
         '$data': {
             handler() {
@@ -16,10 +16,12 @@ export default {
         this.loadState();
     },
 
+    $_saveState: localStorage,
+
     methods: {
         loadState() {
 
-            const savedState = getSavedState(this.getSaveStateConfig().cacheKey);
+            const savedState = this.$options.$_saveState.getSavedState(this.getSaveStateConfig().cacheKey);
 
             if (!savedState) {
                 return;
@@ -42,7 +44,7 @@ export default {
                 return this.attributeIsManagedBySaveState(attribute);
             });
 
-            saveState(this.getSaveStateConfig().cacheKey, data);
+            this.$options.$_saveState.saveState(this.getSaveStateConfig().cacheKey, data);
         },
 
         attributeIsManagedBySaveState(attribute) {
@@ -60,7 +62,9 @@ export default {
         },
 
         clearSavedState() {
-            clearSavedState(this.getSaveStateConfig().cacheKey);
+            this.$options.$_saveState.clearSavedState(this.getSaveStateConfig().cacheKey);
         },
     },
 };
+
+export default localSaveState;

--- a/src/session-storage.js
+++ b/src/session-storage.js
@@ -1,0 +1,15 @@
+function saveState(key, data) {
+    sessionStorage.setItem(key, JSON.stringify(data));
+}
+
+function getSavedState(key) {
+    const savedState = sessionStorage.getItem(key);
+
+    return savedState ? JSON.parse(savedState) : null;
+}
+
+function clearSavedState(key) {
+    sessionStorage.removeItem(key);
+}
+
+export default {saveState, getSavedState, clearSavedState};


### PR DESCRIPTION
This PR adds an equivalent component that uses sessionStorage instead of localStorage. I made some minor modifications to simplify swapping out the methods that reference localStorage. These changes should all be 100% backwards compatible as well.